### PR TITLE
Allow the passing through of options

### DIFF
--- a/lib/restforce/bulk/builder/xml.rb
+++ b/lib/restforce/bulk/builder/xml.rb
@@ -4,14 +4,18 @@ module Restforce
       class Xml
         attr_accessor :operation
 
-        def initialize(operation)
+        def initialize(operation,options={})
           self.operation = operation
+          @options = options
         end
 
         def job(object_name, content_type)
           build_xml(:jobInfo) do |xml|
             xml.operation operation
             xml.object object_name
+            if @options[:externalIdFieldName]
+              xml.externalIdFieldName @options[:externalIdFieldName]
+            end
             xml.contentType content_type
           end
         end

--- a/lib/restforce/bulk/job.rb
+++ b/lib/restforce/bulk/job.rb
@@ -11,8 +11,8 @@ module Restforce
       }
 
       class << self
-        def create(operation, object_name, content_type=:xml)
-          builder  = Restforce::Bulk::Builder::Xml.new(operation)
+        def create(operation, object_name, content_type=:xml, options={})
+          builder  = Restforce::Bulk::Builder::Xml.new(operation, options)
           data     = builder.job(object_name, JOB_CONTENT_TYPE_MAPPING[content_type.to_sym])
 
           response = Restforce::Bulk.client.perform_request(:post, 'job', data)

--- a/lib/restforce/bulk/version.rb
+++ b/lib/restforce/bulk/version.rb
@@ -1,5 +1,5 @@
 module Restforce
   module Bulk
-    VERSION = "0.1.0"
+    VERSION = "0.1.4"
   end
 end

--- a/restforce-bulk.gemspec
+++ b/restforce-bulk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "restforce", "~> 2.1.2"
+  spec.add_dependency "restforce", "~> 2.1"
   spec.add_dependency "nokogiri"
   spec.add_dependency "multi_xml"
   spec.add_dependency "activesupport", "~> 4.2.4"


### PR DESCRIPTION
This allows us to pass through options to the various objects and then
results in us being able to add known fields to the job when
appropriate.

Signed-off-by: Christopher Webber cwebber@chef.io
