### PR TITLE
Nil values serialization

### DIFF
--- a/lib/restforce/bulk.rb
+++ b/lib/restforce/bulk.rb
@@ -8,6 +8,7 @@ require "restforce"
 require "restforce/bulk/version"
 require "active_support/inflector"
 require "zip"
+require "securerandom"
 
 module Restforce
   module Bulk

--- a/lib/restforce/bulk/builder/xml.rb
+++ b/lib/restforce/bulk/builder/xml.rb
@@ -41,7 +41,7 @@ module Restforce
             data.each do |item|
               xml.sObject do
                 item.each do |attr, value|
-                  xml.send(attr, value)
+                  xml.send(attr, value, value.nil? ? {"xsi:nil" => true} : {})
                 end
               end
             end
@@ -52,7 +52,11 @@ module Restforce
 
         def build_xml(root, options={}, &block)
           Nokogiri::XML::Builder.new { |xml|
-            xml.send(root, { xmlns: 'http://www.force.com/2009/06/asyncapi/dataload' }.merge(options), &block)
+            namespaces = {
+              "xmlns" => 'http://www.force.com/2009/06/asyncapi/dataload',
+              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+            }
+            xml.send(root, namespaces.merge(options), &block)
           }.to_xml(encoding: 'UTF-8')
         end
       end

--- a/spec/restforce/bulk/builder/xml_spec.rb
+++ b/spec/restforce/bulk/builder/xml_spec.rb
@@ -1,0 +1,32 @@
+require 'ostruct'
+require "spec_helper"
+
+describe Restforce::Bulk::Builder::Xml, mock_restforce: true do
+  let(:builder) { Restforce::Bulk::Builder::Xml.new(:upsert) }
+
+  def xml(field, value, tag = {})
+    build_bulk_xml(:sObjects) do |builder|
+      builder.sObject {
+        builder.send(field, value, tag)
+      }
+    end
+  end
+
+  it "adds a nil=true tag to nil values" do
+    payload = builder.generate([{IsActive: nil}])
+
+    expect(payload).to eq(xml(:IsActive, nil, "xsi:nil" => true))
+  end
+
+  it "generates non-nil values" do
+    payload = builder.generate([{IsActive: true}])
+
+    expect(payload).to eq(xml(:IsActive, true))
+  end
+
+  it "generates false values" do
+    payload = builder.generate([{IsActive: false}])
+
+    expect(payload).to eq(xml(:IsActive, false))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,8 +48,12 @@ module RestforceMockHelpers
   end
 
   def build_bulk_xml(root, options={}, &block)
+    namespaces = {
+      "xmlns" => 'http://www.force.com/2009/06/asyncapi/dataload',
+      "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+    }
     Nokogiri::XML::Builder.new do |xml|
-      xml.send(root, { xmlns: 'http://www.force.com/2009/06/asyncapi/dataload' }.merge(options), &block)
+      xml.send(root, namespaces.merge(options), &block)
     end.to_xml(encoding: 'UTF-8')
   end
 


### PR DESCRIPTION
To set a `nil` value on an object, the field description needs to have an `xsi:nil` attribute. It is described in Salesfoce [docs](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_xml_valid_records.htm): 
```
To set a field value to null in XML, set the xsi:nil value for the field to true
```

This pull request add an `xsi:nil="true"` tag to nil fields and adds `xsi` namespace to xml payloads.